### PR TITLE
Fix detected module kind and package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,16 +3,17 @@
   "version": "1.2.0",
   "description": "Generate a sequence of numbers for use in a Pagination Component, the clever way.",
   "type": "module",
-  "main": "dist/index.cjs.js",
+  "main": "dist/index.cjs",
   "module": "dist/index.esm.js",
-  "export": {
-    ".": "./dist/index.esm.js",
-    "import": "./dist/index.esm.js",
-    "require": "./dist/index.cjs.js"
+  "exports": {
+    ".": {
+        "require": "./dist/index.cjs"
+        "default": "./dist/index.esm.js"
+    }
   },
   "scripts": {
     "build-esm": "esbuild --bundle ./src/index.js --outfile=./dist/index.esm.js --format=esm --sourcemap --minify",
-    "build-cjs": "esbuild --bundle ./src/index.js --outfile=./dist/index.cjs.js --format=cjs --sourcemap --minify",
+    "build-cjs": "esbuild --bundle ./src/index.js --outfile=./dist/index.cjs --format=cjs --sourcemap --minify",
     "build": "npm run build-esm && npm run build-cjs",
     "prepublish": "npm run build",
     "pretest": "npm run build",


### PR DESCRIPTION
1. `"type": "module"` means that `.js` files are ESM, so having a CJS file named `index.cjs.js` is invalid. For it to be properly detected as CJS under `"type": "module"`, it needs to have a `.cjs` extension. [source](https://nodejs.org/dist/latest-v20.x/docs/api/packages.html#packagejson-and-file-extensions), [publint](https://publint.dev/@bramus/pagination-sequence@1.2.0)
2. The field for controlling package entrypoints is called `exports`, not `export`. [source](https://nodejs.org/dist/latest-v20.x/docs/api/packages.html#package-entry-points)
3. `exports` subpaths (`"."`) cannot be combined with conditions (`"import"`, `"require"`) in the same object. It requires a level of nesting, with the subpaths at the higher level. [source](https://nodejs.org/dist/latest-v20.x/docs/api/packages.html#conditional-exports)

I noticed this while reviewing a DefinitelyTyped contribution for this package at https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65974.